### PR TITLE
fix(nix): pass CARGO_BUILD_TARGET properly

### DIFF
--- a/nix/build-rust-app.nix
+++ b/nix/build-rust-app.nix
@@ -12,11 +12,11 @@ let
     {
       inherit src;
       inherit doCheck;
-      env.CARGO_BUILD_TARGET = lib.mapNullable toString target;
       passthru = {
         inherit craneLib;
       };
     }
+    // lib.optionalAttrs (target != null) { env.CARGO_BUILD_TARGET = "${target}"; }
     // lib.optionalAttrs fixBuildStd {
       # https://github.com/ipetkov/crane/issues/285
       cargoVendorDir = craneLib.vendorMultipleCargoDeps {


### PR DESCRIPTION
This fixes building BOSS kernel on Linux. I am not sure about why that problem did not occur on macOS, but it should be fine now.